### PR TITLE
Disable extension loading in sqlite3 (since the cygwinports package doesn't have it)

### DIFF
--- a/packages/sqlite3/sqlite3.4.0.2/files/no-enable-load-extensions.patch
+++ b/packages/sqlite3/sqlite3.4.0.2/files/no-enable-load-extensions.patch
@@ -1,0 +1,22 @@
+diff -pur8 sqlite3.4.0.2.old/lib/sqlite3_stubs.c sqlite3.4.0.2/lib/sqlite3_stubs.c
+--- sqlite3.4.0.2.old/lib/sqlite3_stubs.c	2016-01-05 13:41:46.619655400 +0100
++++ sqlite3.4.0.2/lib/sqlite3_stubs.c	2016-01-05 13:42:18.252612800 +0100
+@@ -44,17 +44,17 @@
+ # if !defined(__FreeBSD__) && !__APPLE__
+ # define __unused __attribute__ ((unused))
+ # endif
+ #else
+ # define __unused
+ # define inline
+ #endif
+ 
+-#if SQLITE_VERSION_NUMBER >= 3003007
++#if false
+ # define SQLITE_HAS_ENABLE_LOAD_EXTENSION
+ #endif
+ 
+ #if SQLITE_VERSION_NUMBER >= 3003009
+ # define my_sqlite3_prepare sqlite3_prepare_v2
+ #else
+ # define my_sqlite3_prepare sqlite3_prepare
+ #endif

--- a/packages/sqlite3/sqlite3.4.0.2/opam
+++ b/packages/sqlite3/sqlite3.4.0.2/opam
@@ -32,3 +32,6 @@ depexts: [
   [["ubuntu"] ["libsqlite3-dev"]]
   [["win32" "cygwinports"] ["sqlite3"]]
 ]
+patches: [
+  "no-enable-load-extensions.patch"
+]


### PR DESCRIPTION
See https://github.com/mmottl/sqlite3-ocaml/issues/12 ; basically, the sqlite3 package compiled in cygwinports doesn't have loadable extensions, which causes errors at link-time when calling `ocamlfind ocamlopt -package sqlite3`; the temporary fix (until https://github.com/mmottl/sqlite3-ocaml/issues/12 is solved) is to remove that binding from sqlite3.

This is a one-line patch, and will make the sqlite3 opam package usable with your repository (and, with protz.github.io/ocaml-installer/).

Thanks,

Jonathan