### PR TITLE
winfix for frama-c.20151002

### DIFF
--- a/packages/frama-c-base/frama-c-base.20151002/descr
+++ b/packages/frama-c-base/frama-c-base.20151002/descr
@@ -1,0 +1,12 @@
+Platform dedicated to the static analysis of source code written in C
+Frama-C is a suite of tools dedicated to the analysis of the source
+code of software written in C. Magnesium version.
+
+Frama-C gathers several static analysis techniques in a single
+collaborative framework. The collaborative approach of Frama-C allows
+static analyzers to build upon the results already computed by other
+analyzers in the framework. Thanks to this approach, Frama-C provides
+sophisticated tools, such as a slicer and dependency analysis.
+
+This package depends on the minimal number of dependencies (look for
+frama-c for a more complete set of dependencies).

--- a/packages/frama-c-base/frama-c-base.20151002/files/gdk-pixbuf.patch
+++ b/packages/frama-c-base/frama-c-base.20151002/files/gdk-pixbuf.patch
@@ -1,0 +1,21 @@
+diff --git a/src/plugins/gui/gtk_helper.ml b/src/plugins/gui/gtk_helper.ml
+index 8ccfecc..401d751 100644
+--- a/src/plugins/gui/gtk_helper.ml
++++ b/src/plugins/gui/gtk_helper.ml
+@@ -34,9 +34,14 @@ let framac_logo, framac_icon =
+       Some (GdkPixbuf.from_file (Config.datadir ^ "/frama-c." ^ ext))
+     in
+     img "gif", img "ico"
+-  with Glib.GError _ ->
++  with
++  | Glib.GError _ ->
+     Gui_parameters.warning
+-      "Frama-C images not found. Is FRAMAC_SHARE correctly set?";
++      "Frama-C icon/logo not found. Is FRAMAC_SHARE correctly set?";
++    None, None
++  | GdkPixbuf.GdkPixbufError (_, errmsg) ->
++    Gui_parameters.warning
++      "Could not load Frama-C icon/logo: %s" errmsg;
+     None, None
+ 
+ module Icon = struct

--- a/packages/frama-c-base/frama-c-base.20151002/files/makefile-ocamldep.patch
+++ b/packages/frama-c-base/frama-c-base.20151002/files/makefile-ocamldep.patch
@@ -1,0 +1,35 @@
+diff --git a/Makefile b/Makefile
+index 5f4323e..f12237c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -130,10 +130,9 @@ INCLUDES_FOR_OCAMLDEP=$(addprefix -I , $(FRAMAC_SRC_DIRS)) \
+ DEP_FLAGS= $(shell echo $(INCLUDES_FOR_OCAMLDEP) \
+              | $(SED) -e "s/-I *.:[^ ]*//g" -e "s/-I *+[^ ]*//g")
+ 
+-# Files for which dependencies are computed
+-FILES_FOR_OCAMLDEP+=$(PLUGIN_LIB_DIR)/*.mli \
+-		$(addsuffix /*.mli, $(FRAMAC_SRC_DIRS)) \
+-		$(addsuffix /*.ml, $(FRAMAC_SRC_DIRS))
++# Files for which dependencies must be computed computed.
++# Other files are added later in this Makefile.
++FILES_FOR_OCAMLDEP+=$(PLUGIN_LIB_DIR)/*.mli
+ 
+ # Developments flags to be used by ocamlc and ocamlopt when compiling Frama-C
+ # itself. For development versions, we add -warn-error for most warnings
+@@ -1234,8 +1233,6 @@ PLUGIN_INTERNAL_TEST:=yes
+ PLUGIN_DEPENDENCIES:=Pdg Callgraph Value
+ include share/Makefile.plugin
+ 
+-FILES_FOR_OCAMLDEP+=$(TEST_SLICING_ML)
+-
+ #####################
+ # External plug-ins #
+ #####################
+@@ -1325,7 +1322,6 @@ GUI_INCLUDES = -I src/plugins/gui -I $(PLUGIN_LIB_DIR)/gui -I $(LABLGTK_PATH)
+ INCLUDES_FOR_OCAMLDEP+=-I src/plugins/gui
+ BYTE_GUI_LIBS+= lablgtk.cma
+ OPT_GUI_LIBS += lablgtk.cmxa
+-FILES_FOR_OCAMLDEP+= src/plugins/gui/*.ml src/plugins/gui/*.mli
+ 
+ ifeq ("$(OCAMLGRAPH_LOCAL)","")
+ GUI_INCLUDES += $(OCAMLGRAPH)

--- a/packages/frama-c-base/frama-c-base.20151002/files/run_autoconf_if_needed.sh
+++ b/packages/frama-c-base/frama-c-base.20151002/files/run_autoconf_if_needed.sh
@@ -1,0 +1,3 @@
+if [ ! -f "configure" ]; then
+  autoconf
+fi

--- a/packages/frama-c-base/frama-c-base.20151002/files/windows_make.sh
+++ b/packages/frama-c-base/frama-c-base.20151002/files/windows_make.sh
@@ -1,0 +1,12 @@
+# This script allows Frama-C to be compiled under Cygwin + MinGW OCaml
+
+# Test if 'cygpath' exists, otherwise assume we are not compiling under Cygwin
+command -v cygpath >/dev/null 2>&1
+if [ $? -eq 0 ]
+then
+    # Fix path using cygpath
+    make FRAMAC_TOP_SRCDIR="$(cygpath -a -m $PWD)" $*
+else
+    # No cygpath? Nothing special to do
+    make $*
+fi

--- a/packages/frama-c-base/frama-c-base.20151002/opam
+++ b/packages/frama-c-base/frama-c-base.20151002/opam
@@ -1,0 +1,110 @@
+opam-version: "1.2"
+name: "frama-c-base"
+version: "20151002"
+maintainer: "francois.bobot@cea.fr"
+authors: [
+  "Patrick Baudin"
+  "François Bobot"
+  "Richard Bonichon"
+  "David Bühler"
+  "Loïc Correnson"
+  "Pascal Cuoq"
+  "Zaynah Dargaye"
+  "Jean-Christophe Filliâtre"
+  "Philippe Herrmann"
+  "Florent Kirchner"
+  "Matthieu Lemerre"
+  "Claude Marché"
+  "André Maroneze"
+  "Benjamin Monate"
+  "Yannick Moy"
+  "Anne Pacalet"
+  "Valentin Perrelle"
+  "Guillaume Petiot"
+  "Virgile Prevosto"
+  "Armand Puccetti"
+  "Muriel Roger"
+  "Julien Signoles"
+  "Boris Yakobowski"
+]
+homepage: "http://frama-c.com/"
+license: "GNU Lesser General Public License version 2.1"
+doc: ["http://frama-c.com/download/user-manual-Magnesium-20151002.pdf"]
+bug-reports: "https://bts.frama-c.com/"
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "C"
+  "plugins"
+  "abstract interpretation"
+  "slicing"
+  "weakest precondition"
+  "ACSL"
+  "dataflow analysis"
+]
+
+patches: [
+  "gdk-pixbuf.patch" { os = "win32" }
+  "makefile-ocamldep.patch" { os = "win32" }
+]
+
+build: [
+  ["./run_autoconf_if_needed.sh"] #when used in pinned mode the configure
+                                  #*cannot* yet be generated
+  ["./configure" "--prefix" prefix "--disable-local-ocamlgraph"
+                 "--disable-gui" { !conf-gtksourceview:installed |
+                                   !conf-gnomecanvas:installed } ]
+  [make "-j" jobs] { os != "win32" }
+  ["./windows_make.sh" "-j" jobs] { os = "win32" }
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["./run_autoconf_if_needed.sh"] #when used in pinned mode the configure
+                                        #*cannot* yet be generated
+  ["./configure" "--prefix" prefix "--disable-local-ocamlgraph"
+                 "--disable-gui" { !conf-gtksourceview:installed | !conf-gnomecanvas:installed }
+]
+  [make "uninstall"]
+  ["rm" "-rf" frama-c:doc]
+]
+
+build-doc: [
+   [make "-C" "doc" "download"]
+   [make "-C" "doc" "FRAMAC_DOCDIR=%{frama-c:doc}%" "install"]
+]
+
+build-test: [
+  [make "PTESTS_OPTS=-error-code" "tests"]
+]
+
+depends: [
+  "ocamlgraph" { = "1.8.5" | = "1.8.6" }
+  "ocamlfind"
+]
+
+depopts: [
+  "zarith"
+  "lablgtk"
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "coq" { build }
+]
+
+messages: [
+   "Why3 can be used by the WP plugin for running additional automatic solvers" { !why3:installed }
+   "Coq can be used with the WP plugin for proving interactively proof obligations" { !coq:installed }
+]
+
+conflicts: [
+  "why3" { < "0.85" }
+  "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
+]
+
+available: [ ocaml-version >= "4.00.1" & ocaml-version != "4.02.0" & ocaml-version != "4.02.2" ]

--- a/packages/frama-c-base/frama-c-base.20151002/url
+++ b/packages/frama-c-base/frama-c-base.20151002/url
@@ -1,0 +1,2 @@
+http: "http://frama-c.com/download/frama-c-Magnesium-20151002.tar.gz"
+checksum: "b7d761bdf0a58f3f8ec4242a3b67d50a"

--- a/packages/frama-c/frama-c.20151002/descr
+++ b/packages/frama-c/frama-c.20151002/descr
@@ -1,0 +1,11 @@
+Platform dedicated to the static analysis of source code written in C
+Frama-C is a suite of tools dedicated to the analysis of the source
+code of software written in C. Magnesium version.
+
+Frama-C gathers several static analysis techniques in a single
+collaborative framework. The collaborative approach of Frama-C allows
+static analyzers to build upon the results already computed by other
+analyzers in the framework. Thanks to this approach, Frama-C provides
+sophisticated tools, such as a slicer and dependency analysis.
+
+This virtual package forces the installation of frama-C with its IDE.

--- a/packages/frama-c/frama-c.20151002/opam
+++ b/packages/frama-c/frama-c.20151002/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+name: "frama-c"
+version: "20151002"
+maintainer: "francois.bobot@cea.fr"
+authors: [
+  "Patrick Baudin"
+  "François Bobot"
+  "Richard Bonichon"
+  "David Bühler"
+  "Loïc Correnson"
+  "Pascal Cuoq"
+  "Zaynah Dargaye"
+  "Jean-Christophe Filliâtre"
+  "Philippe Herrmann"
+  "Florent Kirchner"
+  "Matthieu Lemerre"
+  "Claude Marché"
+  "André Maroneze"
+  "Benjamin Monate"
+  "Yannick Moy"
+  "Anne Pacalet"
+  "Valentin Perrelle"
+  "Guillaume Petiot"
+  "Virgile Prevosto"
+  "Armand Puccetti"
+  "Muriel Roger"
+  "Julien Signoles"
+  "Boris Yakobowski"
+]
+homepage: "http://frama-c.com/"
+license: "GNU Lesser General Public License version 2.1"
+doc: ["http://frama-c.com/download/user-manual-Magnesium-20151002.pdf"]
+bug-reports: "https://bts.frama-c.com/"
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "C"
+  "plugins"
+  "abstract interpretation"
+  "slicing"
+  "weakest precondition"
+  "ACSL"
+  "dataflow analysis"
+]
+
+depends: [
+  "frama-c-base" { = "20151002" }
+  "zarith"
+  "lablgtk" { >= "2.18.2" } #for ocaml >= 4.02.1
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+]
+
+available: [ ocaml-version >= "3.12" & ocaml-version != "4.02.0" ]


### PR DESCRIPTION
This adds Frama-C version 20151002 (ported from opam-repository) to your MinGW repository, with the necessary patches for the Windows version to compile.

I was able to compile it myself using these patches, but I still needed to do `opam install depext depext-cygwinports` and then `opam depext` for some of the dependencies, such as `gmp` and `lablgtk`.

In other words, from a newly-installed opam, doing `opam install frama-c` directly will not succeed. But when I tested something such as `opam install zarith` without installing the depext beforehand, it didn't work either, so I'm assuming it's just the way it's supposed to work.

If I'm wrong, and you'd like it to work "from scratch", just tell me and I'll propose another patch.