### PR TITLE
fixes for frama-c-base.20160501

### DIFF
--- a/packages/frama-c-base/frama-c-base.20160501/files/fix-cygwin.patch
+++ b/packages/frama-c-base/frama-c-base.20160501/files/fix-cygwin.patch
@@ -1,0 +1,13 @@
+diff --git a/share/Makefile.common b/share/Makefile.common
+index fcce208..dc53a9a 100644
+--- a/share/Makefile.common
++++ b/share/Makefile.common
+@@ -54,7 +54,7 @@ FRAMAC_SRC_DIRS:= $(addprefix src/, $(FRAMAC_SRC_DIRS))
+ 
+ ifeq ($(OCAMLWIN32),yes)
+ ifneq ($(CYGPATH),no)
+-winpath=$(shell $(CYGPATH) -m "$(1)")
++winpath=$(shell $(CYGPATH) -m $(1))
+ else
+ winpath=$(1)
+ endif #CYGPATH

--- a/packages/frama-c-base/frama-c-base.20160501/files/ocamlgraph-1.8.7.patch
+++ b/packages/frama-c-base/frama-c-base.20160501/files/ocamlgraph-1.8.7.patch
@@ -1,0 +1,26 @@
+diff --git a/configure b/configure
+index f9a52e6..682b700 100755
+--- a/configure
++++ b/configure
+@@ -3576,7 +3576,7 @@ $as_echo "$as_me: OcamlGraph $OCAMLGRAPH_VERSION is incompatible with Frama-C."
+       | 1.8.3 | 1.8.3+dev \
+       | 1.8.4 | 1.8.4+dev)
+         ocamlgraph_error;;
+-      1.8.5 | 1.8.6)
++      1.8.5 | 1.8.6 | 1.8.7)
+         { $as_echo "$as_me:${as_lineno-$LINENO}: OcamlGraph $OCAMLGRAPH_VERSION found: great!" >&5
+ $as_echo "$as_me: OcamlGraph $OCAMLGRAPH_VERSION found: great!" >&6;};;
+       1.8.*)
+diff --git a/configure.in b/configure.in
+index fdc28a5..4f0caca 100644
+--- a/configure.in
++++ b/configure.in
+@@ -334,7 +334,7 @@ if test "$ENABLE_LOCAL_OCAMLGRAPH" != "yes"; then
+       | 1.8.3 | 1.8.3+dev \
+       | 1.8.4 | 1.8.4+dev)
+         ocamlgraph_error;;
+-      1.8.5 | 1.8.6)
++      1.8.5 | 1.8.6 | 1.8.7)
+         AC_MSG_NOTICE([OcamlGraph $OCAMLGRAPH_VERSION found: great!]);;
+       1.8.*)
+         AC_MSG_NOTICE(

--- a/packages/frama-c-base/frama-c-base.20160501/files/run_autoconf_if_needed.sh
+++ b/packages/frama-c-base/frama-c-base.20160501/files/run_autoconf_if_needed.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -eux
 
 if [ ! -f "configure" ]; then
-  autoconf
+  autoconf -f
 fi

--- a/packages/frama-c-base/frama-c-base.20160501/opam
+++ b/packages/frama-c-base/frama-c-base.20160501/opam
@@ -58,11 +58,11 @@ build: [
                                    !conf-gnomecanvas:installed }
 ]
   [make "-j%{jobs}%"] {os!="win32"}
-  [make "FRAMAC_TOP_SRCDIR=%{build}%" "all"] {os="win32"}
+  [make "-j%{jobs}%" "FRAMAC_TOP_SRCDIR=%{build}%" "all"] {os="win32"}
 ]
 
 install: [
-  [make "FRAMAC_TOP_SRCDIR=%{build}%" "install"]
+  [make "install"]
 ]
 
 remove: [
@@ -73,22 +73,23 @@ remove: [
                  "--disable-gui" { !conf-gtksourceview:installed |
                                    !conf-gnomecanvas:installed }
 ]
-  [make "FRAMAC_TOP_SRCDIR=%{build}%" "uninstall"]
+  [make "uninstall"] {os!="win32"}
+  [make "FRAMAC_TOP_SRCDIR=%{build}%" "uninstall"] {os="win32"}
   ["rm" "-rf" frama-c:doc]
 ]
 
 build-doc: [
-   [make "FRAMAC_TOP_SRCDIR=%{build}%" "-C" "doc" "download"]
-   [make "FRAMAC_TOP_SRCDIR=%{build}%" "-C" "doc" "FRAMAC_DOCDIR=%{frama-c:doc}%" "install"]
+   [make "-C" "doc" "download"]
+   [make "-C" "doc" "FRAMAC_DOCDIR=%{frama-c:doc}%" "install"]
 ]
 
 build-test: [
   [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"] {os!="win32"}
-  [make "FRAMAC_TOP_SRCDIR=%{build}%" "PTESTS_OPTS=-error-code" "tests"] {os="win32"}
+  [make "-j%{jobs}%" "FRAMAC_TOP_SRCDIR=%{build}%" "PTESTS_OPTS=-error-code" "tests"] {os="win32"}
 ]
 
 depends: [
-  "ocamlgraph" { = "1.8.5" | = "1.8.6" }
+  "ocamlgraph" {>= "1.8.5" & < "1.9~"}
   "ocamlfind"
 ]
 
@@ -105,6 +106,11 @@ messages: [
    "Coq can be used with the WP plug-in for proving interactively proof obligations" { !coq:installed }
 ]
 
+patches: [
+  "ocamlgraph-1.8.7.patch"
+  "fix-cygwin.patch" {os="win32"}
+]
+
 conflicts: [
   "why3-base" { < "0.86" } #for WP plug-in
   "coq"      { < "8.4.6" } #for WP plug-in
@@ -112,4 +118,4 @@ conflicts: [
 ]
 
 available: [ ocaml-version >= "4.00.1" & ocaml-version != "4.02.0" &
-             ocaml-version != "4.02.2" & ocaml-version < "4.04.0" ]
+             ocaml-version != "4.02.2" & ocaml-version < "4.04~" ]


### PR DESCRIPTION
Re-enable compiling Frama-C-20150601 Cygwin.
Also updates compatibility constraints (ocamlgraph 1.8.7 allowed, OCaml 4.04 forbidden).