### PR TITLE
frama-c.20181101 for opam 1.2

### DIFF
--- a/packages/frama-c/frama-c.20181101/descr
+++ b/packages/frama-c/frama-c.20181101/descr
@@ -1,0 +1,15 @@
+Platform dedicated to the analysis of source code written in C.
+
+Frama-C gathers several analysis techniques in a single collaborative
+framework, based on analyzers (called "plug-ins") that can build upon the
+results computed by other analyzers in the framework.
+Thanks to this approach, Frama-C provides sophisticated tools, including:
+- an analyzer based on abstract interpretation (Eva plug-in);
+- a program proof framework based on weakest precondition calculus (WP plug-in);
+- a program slicer (Slicing plug-in);
+- a tool for verification of temporal (LTL) properties (Aoraï plug-in);
+- a runtime verification tool (E-ACSL plug-in);
+- several tools for code base exploration and dependency analysis
+  (plug-ins From, Impact, Metrics, Occurrence, Scope, etc.).
+These plug-ins communicate between each other via the Frama-C API
+and via ACSL (ANSI/ISO C Specification Language) properties.

--- a/packages/frama-c/frama-c.20181101/opam
+++ b/packages/frama-c/frama-c.20181101/opam
@@ -1,0 +1,135 @@
+opam-version: "1.2"
+name: "frama-c"
+version: "20181101"
+maintainer: "francois.bobot@cea.fr"
+authors: [
+  "Michele Alberti"
+  "Thibaud Antignac"
+  "Gergö Barany"
+  "Patrick Baudin"
+  "Lionel Blatter"
+  "François Bobot"
+  "Richard Bonichon"
+  "Quentin Bouillaguet"
+  "David Bühler"
+  "Zakaria Chihani"
+  "Loïc Correnson"
+  "Julien Crétin"
+  "Pascal Cuoq"
+  "Zaynah Dargaye"
+  "Jean-Christophe Filliâtre"
+  "Philippe Herrmann"
+  "Maxime Jacquemin"
+  "Florent Kirchner"
+  "Tristan Le Gall"
+  "Jean-Christophe Léchenet"
+  "Matthieu Lemerre"
+  "David Maison"
+  "Claude Marché"
+  "André Maroneze"
+  "Melody Méaulle"
+  "Benjamin Monate"
+  "Yannick Moy"
+  "Anne Pacalet"
+  "Valentin Perrelle"
+  "Guillaume Petiot"
+  "Virgile Prevosto"
+  "Armand Puccetti"
+  "Muriel Roger"
+  "Julien Signoles"
+  "Kostyantyn Vorobyov"
+  "Boris Yakobowski"
+]
+homepage: "http://frama-c.com/"
+license: "GNU Lesser General Public License version 2.1"
+dev-repo: "https://github.com/Frama-C/Frama-C-snapshot.git#latest"
+doc: "http://frama-c.com/download/user-manual-18.0-Argon.pdf"
+bug-reports: "https://bts.frama-c.com/"
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "C"
+  "plugins"
+  "abstract interpretation"
+  "slicing"
+  "weakest precondition"
+  "ACSL"
+  "dataflow analysis"
+  "runtime verification"
+]
+
+build: [
+  ["autoconf"] {pinned}
+  ["./configure" "--prefix" prefix
+                 "--disable-gui" { !conf-gtksourceview:installed |
+                                   !conf-gnomecanvas:installed }
+                 "--mandir=%{man}%"
+  ]
+  [make "-j%{jobs}%"]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["./configure" "--prefix" prefix
+                 "--disable-gui" { !conf-gtksourceview:installed |
+                                   !conf-gnomecanvas:installed }
+  ]
+  [make "uninstall"]
+  ["rm" "-rf" doc]
+]
+
+build-doc: [
+   [make "-C" "doc" "download"]
+   [make "-C" "doc" "install"]
+]
+
+depends: [
+  "ocamlgraph" { >= "1.8.8" & < "1.9~" }
+  "ocamlfind" # needed beyond build stage, used by -load-module
+  "zarith"
+  "conf-autoconf" { build }
+  "lablgtk" { >= "2.18.2" } #for ocaml >= 4.02.1
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "alt-ergo"
+]
+
+depopts: [
+  "yojson" { build }
+  "coq" { build }
+  "why3" { build }
+  "mlgmpidl" { build }
+  "apron" { build }
+]
+
+conflicts: [
+  "why3-base" { < "0.88" } #for WP plug-in
+  "why3" { >= "1.0" } #for WP plug-in
+  "coq"      { < "8.4.6" } #for WP plug-in
+  "lablgtk" { < "2.18.2" } #for ocaml >= 4.02.1
+  "frama-c-e-acsl" #avoid mixing old releases of E-ACSL, it is already
+                   #distributed with this version of Frama-C
+  "frama-c-base"   #avoid mixing old releases of Frama-C, now that only the
+                   #'frama-c' package exists
+]
+
+messages: [
+  "Yojson enables kernel option -json-compilation-database"
+    {!yojson:installed}
+  "Why3 can be used by the WP plug-in for running additional automatic solvers"
+    {!why3:installed}
+  "Coq can be used with the WP plug-in for proving interactively proof obligations"
+    {!coq:installed}
+  "Alt-Ergo Graphical Interface can be used by the WP plug-in"
+    {!altgr-ergo:installed & alt-ergo <= "1.30"}
+  "Note: the package altgr-ergo could prevent the installation of newer versions of Alt-Ergo"
+    {!altgr-ergo:installed & alt-ergo <= "1.30" & ocaml >= "4.04.0"}
+  "Note: the installed package altgr-ergo could prevent the installation of newer versions of Alt-Ergo"
+    {altgr-ergo:installed & ocaml >= "4.04.0"}
+]

--- a/packages/frama-c/frama-c.20181101/url
+++ b/packages/frama-c/frama-c.20181101/url
@@ -1,0 +1,2 @@
+src: "https://frama-c.com/download/frama-c-18.0-Argon.tar.gz"
+checksum: "659cf094d6e92a8adeb5863ec229020b"


### PR DESCRIPTION
Backport of Frama-C 18 (Argon) for opam 1.2, following the old version numbering (frama-c.20181101).