### PR TITLE
Support for camlidl 1.06

### DIFF
--- a/packages/camlidl/camlidl.1.06/files/META
+++ b/packages/camlidl/camlidl.1.06/files/META
@@ -1,0 +1,4 @@
+description = "Stub generator"
+version = "1.05"
+archive(byte,plugin) = "com.cma"
+archive(native) = "com.cmxa"

--- a/packages/camlidl/camlidl.1.06/files/camlidl.install
+++ b/packages/camlidl/camlidl.1.06/files/camlidl.install
@@ -1,0 +1,20 @@
+bin: [
+ "?compiler/camlidl"
+ "?compiler/camlidl.exe"
+]
+lib: [
+  "META"
+  "lib/com.cma"
+  "lib/com.cmxa"
+  "lib/com.cmi"
+ "?lib/com.a"
+ "?lib/com.lib"
+ "?runtime/libcamlidl.a"
+ "?runtime/libcamlidl.lib"
+ "?runtime/cfactory.obj"
+  "runtime/camlidlruntime.h" { "caml/camlidlruntime.h" }
+]
+stublibs: [
+ "?runtime/dllcamlidl.so"
+ "?runtime/dllcamlidl.dll"
+]

--- a/packages/camlidl/camlidl.1.06/files/disable-fatal-warn-31.diff
+++ b/packages/camlidl/camlidl.1.06/files/disable-fatal-warn-31.diff
@@ -1,0 +1,24 @@
+diff -Naur camlidl-1.05/config/Makefile.unix camlidl-1.05-patched/config/Makefile.unix
+--- camlidl-1.05/config/Makefile.unix	2002-04-22 12:50:46.000000000 +0100
++++ camlidl-1.05-patched/config/Makefile.unix	2016-05-04 13:10:23.370704022 +0100
+@@ -37,7 +37,7 @@
+ BINDIR=/usr/local/bin
+ 
+ # The Objective Caml compilers (the defaults below should be OK)
+-OCAMLC=ocamlc -g
++OCAMLC=ocamlc -g -warn-error -31
+ OCAMLOPT=ocamlopt
+ OCAMLYACC=ocamlyacc -v
+ OCAMLLEX=ocamllex
+diff -Naur camlidl-1.05/config/Makefile.win32 camlidl-1.05-patched/config/Makefile.win32
+--- camlidl-1.05/config/Makefile.win32	2004-07-08 13:21:58.000000000 +0100
++++ camlidl-1.05-patched/config/Makefile.win32	2016-05-04 13:10:23.370704022 +0100
+@@ -35,7 +35,7 @@
+ BINDIR=C:/ocaml/bin
+ 
+ # The Objective Caml compilers (the defaults below should be OK)
+-OCAMLC=ocamlc -g
++OCAMLC=ocamlc -g -warn-error -31
+ OCAMLOPT=ocamlopt
+ OCAMLDEP=ocamldep
+ OCAMLYACC=ocamlyacc -v

--- a/packages/camlidl/camlidl.1.06/files/patch-so.diff
+++ b/packages/camlidl/camlidl.1.06/files/patch-so.diff
@@ -1,0 +1,31 @@
+diff --git a/runtime/Makefile.unix b/runtime/Makefile.unix
+index a60ed9d..375cd89 100644
+--- a/runtime/Makefile.unix
++++ b/runtime/Makefile.unix
+@@ -14,9 +14,15 @@
+ 
+ OBJS=idlalloc.o comintf.o comerror.o
+ 
+-all: dllcamlidl.so libcamlidl.a
++ifeq ($(OS),Windows_NT)
++SO:=dll
++else
++SO:=so
++endif
+ 
+-dllcamlidl.so libcamlidl.a: $(OBJS)
++all: dllcamlidl.$(SO) libcamlidl.a
++
++dllcamlidl.$(SO) libcamlidl.a: $(OBJS)
+ 	- rm -f $@
+ 	ocamlmklib -o camlidl  $(OBJS) 
+ 
+@@ -28,7 +34,7 @@ dllcamlidl.so libcamlidl.a: $(OBJS)
+ install:
+ 	cp camlidlruntime.h $(OCAMLLIB)/caml/camlidlruntime.h
+ 	cp libcamlidl.a $(OCAMLLIB)/libcamlidl.a
+-	cp dllcamlidl.so $(OCAMLLIB)/stublibs/dllcamlidl.so
++	cp dllcamlidl.$(SO) $(OCAMLLIB)/stublibs/dllcamlidl.$(SO)
+ 	cd $(OCAMLLIB); $(RANLIB) libcamlidl.a
+ 
+ clean:

--- a/packages/camlidl/camlidl.1.06/opam
+++ b/packages/camlidl/camlidl.1.06/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Nicolas Berthier <m@nberth.space>"
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlidl"
+dev-repo: "git+https://github.com/xavierleroy/camlidl.git"
+bug-reports: "https://github.com/xavierleroy/camlidl/issues"
+license: "QPL-1.0 and LGPL-2 with exceptions"
+build: [
+  ["mv" "config/Makefile.unix" "config/Makefile"]
+    {os = "macos" | os = "linux" | os = "freebsd" | os = "bsd" | os = "unix" |
+     os = "cygwin"}
+  ["mv" "config/Makefile.unix" "config/Makefile"] {os = "win32"}
+  [make "all"]
+]
+patches: [
+  "disable-fatal-warn-31.diff" {ocaml:version >= "4.03"}
+  "patch-so.diff"
+]
+synopsis: "Stub code generator for OCaml"
+description: """
+CamlIDL is a stub code generator for OCaml. It automates the
+generation of C stub code required for the Caml/C interface, based on
+an MIDL specification. Also provides some support for Microsoft's COM
+software components."""
+depends: ["ocaml"]
+extra-files: [
+  ["disable-fatal-warn-31.diff" "md5=750eef544a6a4f4835b819ca8d740924"]
+  ["patch-so.diff" "md5=1749871e7867c9016d15761affbd2d87"]
+  ["camlidl.install" "md5=a343cf3f23bcd4a9092dd5024014ccaf"]
+  ["META" "md5=66b8e0b9187f7b2d25301e431ff779d9"]
+]
+url {
+  src:
+    "https://github.com/xavierleroy/camlidl/archive/camlidl106.tar.gz"
+  checksum: "md5=f73f15ecf7e697372908aec327a2405a"
+}


### PR DESCRIPTION
As far as I can tell, a MinGW build of Camlidl has always been possible. Still, since I cannot easily check this, I only updated a new package for Camlidl 1.06, which has been released in the meantime.

I did not use the package description for Camlidl 1.05, in particular the `camlidl-1.05.patch`. It seemed simpler to use the `Makefile.unix` template instead, as it almost works. A PR has been opened for `patch-so.diff` at https://github.com/xavierleroy/camlidl/pull/10.