### PR TITLE
Fix base-v.11.1 fix

### DIFF
--- a/packages/base/base.v0.11.1/files/base-v0.11.1.patch
+++ b/packages/base/base.v0.11.1/files/base-v0.11.1.patch
@@ -50,7 +50,7 @@
       (with-stdout-to popcnt_test.c
        (echo "int main(int argc, char ** argv) { return __builtin_popcount(argc); }"))
 -     (system "${CC} -mpopcnt -c popcnt_test.c 2> ${null} && \
-+     (bash "${CC} -mpopcnt -c popcnt_test.c 2> ${null} && \
++     (bash "${CC} -mpopcnt -c popcnt_test.c 2> /dev/null && \
  echo '(-mpopcnt)' > ${@} || echo '()' > ${@}"))))))
  
  (ocamllex (hex_lexer))


### PR DESCRIPTION
I had to replace `${null}` with `/dev/null` for the fix to work. In my environment (Cygwin) `${null}` expands to a local file called `nul` and later `dune` fails trying to delete this file. Using unix-ism like `/dev/null` is warranted here, I think, since it is already explicitly calls into `bash`.

This works for me, but I don't know if this will work for everybody. Presumably this worked before for some setups?
