### PR TITLE
[why3] backport cherry-picked Windows-specific fixes

### DIFF
--- a/packages/why3/why3.1.2.1/files/execv_quote_arguments.patch
+++ b/packages/why3/why3.1.2.1/files/execv_quote_arguments.patch
@@ -1,0 +1,13 @@
+--- a/src/tools/main.ml
++++ b/src/tools/main.ml
+@@ -103,7 +103,9 @@ let command sscmd =
+       Filename.concat command_path scmd
+     end in
+   let scmd = "why3 " ^ sscmd in
+-  Unix.execv cmd (Array.of_list (scmd :: args))
++  (* add double quotes to avoid splitting issues with execv in Windows *)
++  let quote = if Sys.win32 then Filename.quote else (fun s -> s) in
++  Unix.execv cmd (Array.of_list (List.map quote (scmd :: args)))
+ 
+ let () = try
+   let extra_help fmt () = extra_help fmt (available_commands ()) in

--- a/packages/why3/why3.1.2.1/files/prove_client_socket_basename.patch
+++ b/packages/why3/why3.1.2.1/files/prove_client_socket_basename.patch
@@ -1,0 +1,11 @@
+--- a/src/driver/prove_client.ml
++++ b/src/driver/prove_client.ml
+@@ -22,7 +22,7 @@ let client_connect ~fail socket_name =
+   try
+     let sock =
+       if Sys.os_type = "Win32" then
+-        let name = "\\\\.\\pipe\\" ^ socket_name in
++        let name = "\\\\.\\pipe\\" ^ Filename.basename socket_name in
+         Unix.openfile name [Unix.O_RDWR] 0
+       else
+       let sock = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in

--- a/packages/why3/why3.1.2.1/opam
+++ b/packages/why3/why3.1.2.1/opam
@@ -22,6 +22,11 @@ tags: [
   "interactive theorem prover"
 ]
 
+patches: [
+  "execv_quote_arguments.patch"
+  "prove_client_socket_basename.patch"
+]
+
 build: [
   ["./autogen.sh"] {dev} # when pinning, there might be no configure file
   ["./configure"


### PR DESCRIPTION
When testing Why3 on Windows, I stumbled upon these two issues, which were fixed in the Why3 master branch. However, I need them on Why3 1.2.1, and since they are Windows-specific, I think it would be useful to backport them here.