### PR TITLE
Mark pkcs11-driver 1.0.0 as available on Windows

### DIFF
--- a/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
@@ -26,7 +26,7 @@ conflicts: [
   "ctypes" { < "0.12.0" }
 ]
 tags: ["org:cryptosense"]
-available: os != "macos" & os != "win32"
+available: os != "macos"
 synopsis: "Bindings to the PKCS#11 cryptographic API"
 description: """
 This library contains ctypes bindings to the PKCS#11 API.


### PR DESCRIPTION
I've installed it yesterday and it worked.

Is there any reason why it might have been marked as unavailable?