### PR TITLE
Compiler newer version of GTKsourceview from sources

### DIFF
--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -5,7 +5,11 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL-2.1-or-later"
 build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
-depends: ["conf-pkg-config" {build}]
+depends: [
+  "conf-pkg-config" {build}
+  "dep-glib-compiled-schemas" {os = "win32" & os-distribution = "cygwinports"}
+  "dep-gtksourceview3" {os = "win32" & os-distribution = "cygwinports"}
+]
 depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
   ["gtksourceview3"] {os-distribution = "arch"}

--- a/packages/dep-glib-compiled-schemas/dep-glib-compiled-schemas.1.0/opam
+++ b/packages/dep-glib-compiled-schemas/dep-glib-compiled-schemas.1.0/opam
@@ -1,0 +1,14 @@
+# Note: cygwin does not compile the glib schemas
+
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "Michael Soegtrop"
+bug-reports: "https://github.com/MSoegtropIMC/coq-platform/issues"
+homepage: "https://github.com/MSoegtropIMC/coq-platform/"
+license: "LGPL-2.1-or-later"
+install: [ "glib-compile-schemas" "/usr/%{arch}%-w64-mingw32/sys-root/mingw/share/glib-2.0/schemas/" ]
+depends: [
+  "conf-gtk3"
+]
+synopsis: "Compiled schemas for glib for MinGW with cygwhin build host"
+available: os = "win32" & os-distribution = "cygwinports"

--- a/packages/dep-gtksourceview3/dep-gtksourceview3.24.11/opam
+++ b/packages/dep-gtksourceview3/dep-gtksourceview3.24.11/opam
@@ -1,0 +1,25 @@
+# Note: the cygwin package is version 3.24.6.1 which has a severe bug in DLL_MAIN
+# Whenever a thread is closed, it deletes some global context objects which later leads to crashes
+
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "The gtksourceview programmers"
+bug-reports: "https://github.com/MSoegtropIMC/coq-platform/issues"
+homepage: "https://projects.gnome.org/gtksourceview/"
+license: "LGPL-2.1-or-later"
+build: [
+  # Note: this installs to a path outside of .opam which will not work with sandboxing, but this is anyway off on Windows
+  # The reason is that pkg-config doesn't find the .pc file it is installed under .opam
+  [ "./configure" "--build=%{arch}%-pc-cygwin" "--host=%{arch}%-w64-mingw32" "--target=%{arch}%-w64-mingw32" "--prefix=/usr/%{arch}%-w64-mingw32/sys-root/mingw" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+depends: [
+  "conf-gtk3"
+]
+synopsis: "Package gtksourceview3 for MinGW with cygwhin build host compiled from sources"
+url {
+  src: "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz"
+  checksum: "sha512=3490b34c6432a2e2ef292ad5bf982fdd22d33b1472434549b4ea8ddae0fc8808e128ef947e4d0dcb41e8de5e601b202f52532bbbbfa11d35050acfc42f9936b2"
+}
+available: os = "win32" & os-distribution = "cygwinports"


### PR DESCRIPTION
This PR has two changes:
- Compiler newer version of GTKsourceview from sources
- Compile the MinGW GTK resources - without this MinGW GTK apps cannot e.g. use a file dialog

The latest version of gtksourceview for MinGW from Cygwin is `3.24.6-1` which is severely broken (it deletes important data structures whenever a thread ends which will crash all remaining threads after a while). This patch compiles a fixed version (3.24.11) from sources.

I am working on getting both fixed on Cygwin side, but it might take a while.