### PR TITLE
Added MinGW binary pkg-config wrapper

### DIFF
--- a/packages/dep-pkg-config-mingw/dep-pkg-config-mingw.1.0/files/pkg-config.c
+++ b/packages/dep-pkg-config-mingw/dep-pkg-config-mingw.1.0/files/pkg-config.c
@@ -1,0 +1,29 @@
+// MinGW personality wrapper for pkgconf
+// This is an executable replacement for the shell scripts /bin/ARCH-pkg-config
+// Compile with e.g.
+// gcc pkg-config.c -DARCH=x86_64-w64-mingw32 -o pkg-config.exe
+// gcc pkg-config.c -DARCH=i686-w64-mingw32 -o pkg-config.exe
+// ATTENTION: Do not compile with MinGW-gcc, compile with cygwin gcc!
+//
+// To test it execute e.g.
+// $ ./pkg-config --path zlib
+// /usr/x86_64-w64-mingw32/sys-root/mingw/lib/pkgconfig/zlib.pc
+
+#include <unistd.h>
+
+#define STRINGIFY1(arg) #arg
+#define STRINGIFY(arg) STRINGIFY1(arg)
+
+int main(int argc, char *argv[])
+{
+    // +1 for extra argument, +1 for trailing NULL
+    char * argvnew[argc+2];
+    int id=0, is=0;
+
+    argvnew[id++] = argv[is++];
+    argvnew[id++] = "--personality="STRINGIFY(ARCH);
+    while( is<argc ) argvnew[id++] = argv[is++];
+    argvnew[id++] = 0;
+
+    return execv("/usr/bin/pkgconf", argvnew);
+}

--- a/packages/dep-pkg-config-mingw/dep-pkg-config-mingw.1.0/opam
+++ b/packages/dep-pkg-config-mingw/dep-pkg-config-mingw.1.0/opam
@@ -1,0 +1,19 @@
+# cygwin replaced ARCH-pkg-config with a shell script, which doesn't work e.g. for dune on Windows.
+# This builds a binary replacement for the shell script and puts it into the opam switch bin folder.
+# Note: this buids a cygwin executable and needs cygwin gcc. Not sure what the conf package for this would be.
+
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "Michael Soegtrop"
+bug-reports: "https://github.com/MSoegtropIMC/coq-platform/issues"
+homepage: "https://github.com/MSoegtropIMC/coq-platform/"
+license: "LGPL-2.1-or-later"
+extra-files: [
+  ["pkg-config.c" "sha512=ea257df4d4715f7a16437d1fc6cfc34d5db159d43089ba34efdcda7d27ed83026f5cb5b0f90e42942e81af7cb01484661596cf1132e777cb23b5f8adc200e52c"]
+]
+build: [
+  [ "gcc" "-DARCH=%{arch}%-w64-mingw32" "-o" "pkg-config.exe" "pkg-config.c" ]
+]
+install: [ "cp" "pkg-config.exe" bin ]
+synopsis: "A pkg-config executable for MinGW packages on cygwin hosts"
+available: os = "win32" & os-distribution = "cygwinports"


### PR DESCRIPTION
This PR adds a binary MinGW wrapper for pkg-config.

The wrapper povided by Cygwin is a shell script and cannot be called e.g. by MinGW opam.