### PR TITLE
config-file: revert to old tarball

### DIFF
--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -16,6 +16,6 @@ remove: [
 depends: ["ocaml" "ocamlfind" "camlp4"]
 synopsis: "Small library to define, load and save options files."
 url {
-  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.1/old-codes-config-file-1.1.tar.gz"
-  checksum: "md5=77b0e72a15fe22868c6eceb8ba1f7325"
+  src:"https://github.com/ocaml/opam-source-archives/raw/main/config-file-1.1.tar.gz"
+  checksum: "md5=7bc051234ceb29ffd5823ee6bcffe19c"
 }

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -22,6 +22,6 @@ synopsis: "Small library to define, load and save options files."
 flags: light-uninstall
 extra-files: ["patch-aa" "md5=3f359cff269d6e7ea401c683618a40f2"]
 url {
-  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.2/old-codes-config-file-1.2.tar.gz"
-  checksum: "md5=2f3679799ae8e3bc67847a204aae71c9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/config-file-1.2.tar.gz"
+  checksum: "md5=fece1f143285fb5fddf17d5d36a577c5"
 }


### PR DESCRIPTION
The new one has a small change which, in particular, creates issue to a patch needed for windows

This is a port of the patch from @mseri in https://github.com/ocaml/opam-repository/pull/20313 which should fix an issue with OCaml github actions builds on Windows.